### PR TITLE
Capture warnings.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,12 @@ chronological order. Releases follow [semantic versioning](https://semver.org/) 
 releases are available on [PyPI](https://pypi.org/project/pytask-parallel) and
 [Anaconda.org](https://anaconda.org/conda-forge/pytask-parallel).
 
-## 0.2.0 - 2022-xx-xx
+## 0.2.1 - 2022-08-xx
+
+- {pull}`43` adds docformatter.
+- {pull}`44` allows to capture warnings from subprocesses. Fixes {issue}`41`.
+
+## 0.2.0 - 2022-04-15
 
 - {pull}`31` adds types to the package.
 - {pull}`36` adds a test for <https://github.com/pytask-dev/pytask/issues/216>.

--- a/README.md
+++ b/README.md
@@ -68,13 +68,20 @@ n_workers = 1
 parallel_backend = "loky"  # or processes or threads
 ```
 
-## Warning
+## Some implementation details
+
+### Parallelization and Debugging
 
 It is not possible to combine parallelization with debugging. That is why `--pdb` or
 `--trace` deactivate parallelization.
 
 If you parallelize the execution of your tasks using two or more workers, do not use
 `breakpoint()` or `import pdb; pdb.set_trace()` since both will cause exceptions.
+
+### Threads and warnings
+
+Capturing warnings is not thread-safe. Therefore, warnings cannot be captured reliably
+when tasks are parallelized with `--parallel-backend threads`.
 
 ## Changes
 

--- a/src/pytask_parallel/execute.py
+++ b/src/pytask_parallel/execute.py
@@ -280,7 +280,7 @@ class DefaultBackendNameSpace:
 
 def _mock_processes_for_threads(
     func: Callable[..., Any], **kwargs: Any
-) -> tuple[list[Any], None]:
+) -> tuple[list[Any], tuple[type[BaseException], BaseException, TracebackType] | None]:
     """Mock execution function such that it returns the same as for processes.
 
     The function for processes returns ``warning_reports`` and an ``exception``. With
@@ -289,8 +289,13 @@ def _mock_processes_for_threads(
 
     """
     __tracebackhide__ = True
-    func(**kwargs)
-    return [], None
+    try:
+        func(**kwargs)
+    except Exception:
+        exc_info = sys.exc_info()
+    else:
+        exc_info = None
+    return [], exc_info
 
 
 def _create_kwargs_for_task(task: Task) -> dict[Any, Any]:

--- a/src/pytask_parallel/execute.py
+++ b/src/pytask_parallel/execute.py
@@ -11,9 +11,6 @@ from typing import Any
 from typing import Callable
 
 import cloudpickle
-from _pytask.warnings import parse_warning_filter
-from _pytask.warnings import warning_record_to_str
-from _pytask.warnings_utils import WarningReport
 from pybaum.tree_util import tree_map
 from pytask import console
 from pytask import ExecutionReport
@@ -26,6 +23,16 @@ from pytask import Task
 from pytask_parallel.backends import PARALLEL_BACKENDS
 from rich.console import ConsoleOptions
 from rich.traceback import Traceback
+
+# Can be removed if pinned to pytask >= 0.2.6.
+try:
+    from pytask import parse_warning_filter
+    from pytask import warning_record_to_str
+    from pytask import WarningReport
+except ImportError:
+    from _pytask.warnings import parse_warning_filter
+    from _pytask.warnings import warning_record_to_str
+    from _pytask.warnings_utils import WarningReport
 
 
 @hookimpl

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -119,6 +119,7 @@ def test_pytask_execute_task_w_processes(parallel_backend):
         "n_workers": 2,
         "parallel_backend": parallel_backend,
         "show_locals": False,
+        "filterwarnings": [],
     }
 
     with PARALLEL_BACKENDS[parallel_backend](
@@ -135,7 +136,9 @@ def test_pytask_execute_task_w_processes(parallel_backend):
         future = backend_name_space.pytask_execute_task(session, task)
         executor.shutdown()
 
-    assert future.result() is None
+    warning_reports, exception = future.result()
+    assert warning_reports == []
+    assert exception is None
 
 
 @pytest.mark.end_to_end

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -294,7 +294,11 @@ def test_generators_are_removed_from_depends_on_produces(tmp_path, parallel_back
 
 
 @pytest.mark.end_to_end
-@pytest.mark.parametrize("parallel_backend", PARALLEL_BACKENDS)
+@pytest.mark.parametrize(
+    "parallel_backend",
+    # Capturing warnings is not thread-safe.
+    [backend for backend in PARALLEL_BACKENDS if backend != "threads"],
+)
 def test_collect_warnings_from_parallelized_tasks(runner, tmp_path, parallel_backend):
     source = """
     import pytask

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -315,3 +315,9 @@ def test_collect_warnings_from_parallelized_tasks(runner, tmp_path, parallel_bac
 
     assert result.exit_code == ExitCode.OK
     assert "Warnings" in result.output
+    assert "This is a warning." in result.output
+    assert "capture_warnings.html" in result.output
+
+    warnings_block = result.output.split("Warnings")[1]
+    assert "task_example.py::task_example[0]" in warnings_block
+    assert "task_example.py::task_example[1]" in warnings_block

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -306,7 +306,9 @@ def test_collect_warnings_from_parallelized_tasks(runner, tmp_path, parallel_bac
     """
     tmp_path.joinpath("task_example.py").write_text(textwrap.dedent(source))
 
-    result = runner.invoke(cli, [tmp_path.as_posix(), "-n", "2", "--parallel-backend", parallel_backend])
+    result = runner.invoke(
+        cli, [tmp_path.as_posix(), "-n", "2", "--parallel-backend", parallel_backend]
+    )
 
     assert result.exit_code == ExitCode.OK
     assert "Warnings" in result.output

--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,7 @@ warn-symbols =
 
 [pytest]
 testpaths =
+    # Do not add src since it messes with the loading of pytask-parallel as a plugin.
     tests
 addopts = --doctest-modules
 filterwarnings =

--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,8 @@ warn-symbols =
     pytest.mark.skip = Remove 'skip' flag for tests.
 
 [pytest]
+testpaths =
+    tests
 addopts = --doctest-modules
 filterwarnings =
     ignore: the imp module is deprecated in favour of importlib


### PR DESCRIPTION
Fixes #41.

- [x] Requires a new release of pytask with published functions for capturing warnings. -> flexible imports.
- [x] ~Fix capturing of warnings in threads.~ Added note that capturing warnings is not thread-safe.