### PR TITLE
Raise minimum Python to 3.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - uses: actions/checkout@v6

--- a/docs/source/changes.md
+++ b/docs/source/changes.md
@@ -5,6 +5,10 @@ chronological order. Releases follow [semantic versioning](https://semver.org/) 
 releases are available on [PyPI](https://pypi.org/project/pytask-parallel) and
 [Anaconda.org](https://anaconda.org/conda-forge/pytask-parallel).
 
+## Unreleased
+
+- {pull}`129` drops support for Python 3.8 and 3.9 and adds support for Python 3.14.
+
 ## 0.5.1 - 2025-03-09
 
 - {pull}`114` drops support for Python 3.8 and adds support for Python 3.13.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "attrs>=21.3.0",
     "click>=8.1.8,!=8.2.0",

--- a/src/pytask_parallel/backends.py
+++ b/src/pytask_parallel/backends.py
@@ -8,13 +8,16 @@ from concurrent.futures import Future
 from concurrent.futures import ProcessPoolExecutor
 from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
+from typing import TYPE_CHECKING
 from typing import Any
-from typing import Callable
 from typing import ClassVar
 
 import cloudpickle
 from attrs import define
 from loky import get_reusable_executor
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 __all__ = ["ParallelBackend", "ParallelBackendRegistry", "WorkerType", "registry"]
 

--- a/src/pytask_parallel/utils.py
+++ b/src/pytask_parallel/utils.py
@@ -6,7 +6,6 @@ import inspect
 from functools import partial
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Callable
 
 from pytask import NodeLoadError
 from pytask import PNode
@@ -19,6 +18,7 @@ from pytask_parallel.nodes import RemotePathNode
 from pytask_parallel.typing import is_local_path
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from concurrent.futures import Future
     from pathlib import Path
     from types import ModuleType

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 import sys
 from contextlib import contextmanager
-from typing import Callable
+from typing import TYPE_CHECKING
 
 import pytest
 from click.testing import CliRunner
 from nbmake.pytest_items import NotebookItem
 from pytask import storage
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class SysPathsSnapshot:

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -266,9 +266,11 @@ def test_task_without_path_that_return(runner, tmp_path, parallel_backend):
 @pytest.mark.parametrize("parallel_backend", _IMPLEMENTED_BACKENDS)
 def test_parallel_execution_is_deactivated(runner, tmp_path, flag, parallel_backend):
     tmp_path.joinpath("task_example.py").write_text("def task_example(): pass")
+    input_ = "c\n" if flag == "--trace" else None
     result = runner.invoke(
         cli,
         [tmp_path.as_posix(), "-n", "2", "--parallel-backend", parallel_backend, flag],
+        input=input_,
     )
     assert result.exit_code == ExitCode.OK
     assert "Started 2 workers" not in result.output


### PR DESCRIPTION
- Drop Python 3.8/3.9 support and keep 3.10+\n- Extend CI matrix to 3.10–3.14