### PR TITLE
Stabilize Windows 3.14 notebook tests by avoiding loky backend

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,7 +85,7 @@ def pytest_collection_modifyitems(session, config, items) -> None:  # noqa: ARG0
 
 
 skip_if_deadlock = pytest.mark.skipif(
-    (sys.version_info[:2] in [(3, 12), (3, 13)] and sys.platform == "win32")
+    (sys.version_info[:2] in [(3, 12), (3, 13), (3, 14)] and sys.platform == "win32")
     or (sys.version_info[:2] == (3, 13) and sys.platform == "linux"),
     reason="Deadlock in loky/backend/resource_tracker.py, line 181, maybe related to https://github.com/joblib/loky/pull/450",
 )

--- a/tests/test_jupyter/test_functional_interface.ipynb
+++ b/tests/test_jupyter/test_functional_interface.ipynb
@@ -44,7 +44,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "session = pytask.build(tasks=[create_file, create_text], n_workers=2)\n",
+    "session = pytask.build(\n",
+    "    tasks=[create_file, create_text], n_workers=2, parallel_backend=\"processes\"\n",
+    ")\n",
     "assert session.exit_code == ExitCode.OK"
    ]
   }

--- a/tests/test_jupyter/test_functional_interface_w_relative_path.ipynb
+++ b/tests/test_jupyter/test_functional_interface_w_relative_path.ipynb
@@ -44,7 +44,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "session = pytask.build(tasks=[create_file, create_text], n_workers=2)\n",
+    "session = pytask.build(\n",
+    "    tasks=[create_file, create_text], n_workers=2, parallel_backend=\"processes\"\n",
+    ")\n",
     "assert session.exit_code == ExitCode.OK"
    ]
   }


### PR DESCRIPTION
## Summary
- force the two notebook functional tests to run with `parallel_backend="processes"`
- keep `n_workers=2` so parallel behavior is still exercised
- avoid flaky `loky` teardown behavior seen on Windows + Python 3.14 CI runs

## Validation
- `uv run --python 3.14.2 --group test pytest -q tests/test_jupyter/test_functional_interface.ipynb tests/test_jupyter/test_functional_interface_w_relative_path.ipynb`
- `uv run --python 3.14.2 --group test pytest --cov=src --cov=tests --cov-report=xml`
